### PR TITLE
Native adapter: Do not set url in request

### DIFF
--- a/example/Pipes_test.ml
+++ b/example/Pipes_test.ml
@@ -6,8 +6,6 @@ open Pipes
 
 let fakeConfig = { db = "fake db" }
 
-let fakeBaseUrl = "http://my-api.com"
-
 (* Demonstrates how to test a "real world" application using Noir and BsJest *)
 
 let () =
@@ -15,7 +13,7 @@ let () =
       describe "home" (fun () ->
           testAllPipe "listen to get requests on /" fakeConfig
             [
-              ( Request.make ~verb:`get ~pathName:"/" ~url:(fakeBaseUrl ^ "/") (),
+              ( Request.make ~verb:`get ~pathName:"/" (),
                 home,
                 Response.ok
                   ~headers:
@@ -32,8 +30,7 @@ let () =
       describe "hello" (fun () ->
           testAllPipe "not listen to get /hello" fakeConfig
             [
-              ( Request.make ~verb:`get ~pathName:"/hello"
-                  ~url:(fakeBaseUrl ^ "/hello") (),
+              ( Request.make ~verb:`get ~pathName:"/hello" (),
                 hello,
                 Response.notFound () );
             ];
@@ -41,9 +38,7 @@ let () =
           describe "noir" (fun () ->
               testAllPipe "listen to get /hello/noir" fakeConfig
                 [
-                  ( Request.make ~verb:`get ~pathName:"/hello/noir"
-                      ~url:(fakeBaseUrl ^ "/hello/noir")
-                      (),
+                  ( Request.make ~verb:`get ~pathName:"/hello/noir" (),
                     hello,
                     Response.ok
                       ~headers:
@@ -61,9 +56,7 @@ let () =
               testAllPipe "listen to get /hello/{capture} and capture path part"
                 fakeConfig
                 [
-                  ( Request.make ~verb:`get ~pathName:"/hello/foo"
-                      ~url:(fakeBaseUrl ^ "/hello/foo")
-                      (),
+                  ( Request.make ~verb:`get ~pathName:"/hello/foo" (),
                     hello,
                     Response.ok
                       ~headers:
@@ -79,9 +72,7 @@ let () =
       describe "noContent" (fun () ->
           testAllPipe "listen get /no-content and simply return 204" fakeConfig
             [
-              ( Request.make ~verb:`get ~pathName:"/no-content"
-                  ~url:(fakeBaseUrl ^ "/no-content")
-                  (),
+              ( Request.make ~verb:`get ~pathName:"/no-content" (),
                 noContent,
                 Response.make
                   ~headers:(Js.Dict.fromList [ ("Content-Length", "0") ])
@@ -93,9 +84,7 @@ let () =
       describe "something" (fun () ->
           testAllPipe "listen get /something" fakeConfig
             [
-              ( Request.make ~verb:`get ~pathName:"/something"
-                  ~url:(fakeBaseUrl ^ "/something")
-                  (),
+              ( Request.make ~verb:`get ~pathName:"/something" (),
                 something,
                 Response.ok
                   ~headers:
@@ -113,13 +102,10 @@ let () =
           testAllPipe "serve /with-payload if payload is valid, 404 otherwise"
             fakeConfig
             [
-              ( Request.make ~verb:`post ~pathName:"/with-payload"
-                  ~url:(fakeBaseUrl ^ "/with-payload")
-                  (),
+              ( Request.make ~verb:`post ~pathName:"/with-payload" (),
                 withPayload,
                 Response.make ~status:`badRequest () );
               ( Request.make ~verb:`post ~pathName:"/with-payload"
-                  ~url:(fakeBaseUrl ^ "/with-payload")
                   ~body:(Serializable.fromString "")
                   (),
                 withPayload,
@@ -127,7 +113,6 @@ let () =
                   ~body:(Serializable.fromString "error: Not an object")
                   () );
               ( Request.make ~verb:`post ~pathName:"/with-payload"
-                  ~url:(fakeBaseUrl ^ "/with-payload")
                   ~body:
                     (Serializable.fromString "{\"age\":12,\"name\":\"foo\"}")
                   (),
@@ -146,7 +131,7 @@ let () =
       describe "pipeline" (fun () ->
           testAllPipe "same tests in the pipeline context" fakeConfig
             [
-              ( Request.make ~verb:`get ~pathName:"/" ~url:(fakeBaseUrl ^ "/") (),
+              ( Request.make ~verb:`get ~pathName:"/" (),
                 home,
                 Response.ok
                   ~headers:
@@ -158,13 +143,10 @@ let () =
                        ])
                   ~body:(Serializable.fromString "{\"hello\":\"world\"}")
                   () );
-              ( Request.make ~verb:`get ~pathName:"/hello"
-                  ~url:(fakeBaseUrl ^ "/hello") (),
+              ( Request.make ~verb:`get ~pathName:"/hello" (),
                 hello,
                 Response.notFound () );
-              ( Request.make ~verb:`get ~pathName:"/hello/noir"
-                  ~url:(fakeBaseUrl ^ "/hello/noir")
-                  (),
+              ( Request.make ~verb:`get ~pathName:"/hello/noir" (),
                 hello,
                 Response.ok
                   ~headers:
@@ -176,9 +158,7 @@ let () =
                        ])
                   ~body:(Serializable.fromString "Say hello to Noir!!")
                   () );
-              ( Request.make ~verb:`get ~pathName:"/hello/foo"
-                  ~url:(fakeBaseUrl ^ "/hello/foo")
-                  (),
+              ( Request.make ~verb:`get ~pathName:"/hello/foo" (),
                 hello,
                 Response.ok
                   ~headers:
@@ -188,18 +168,14 @@ let () =
                        ])
                   ~body:(Serializable.fromString "Say hello to foo")
                   () );
-              ( Request.make ~verb:`get ~pathName:"/no-content"
-                  ~url:(fakeBaseUrl ^ "/no-content")
-                  (),
+              ( Request.make ~verb:`get ~pathName:"/no-content" (),
                 noContent,
                 Response.make
                   ~headers:(Js.Dict.fromList [ ("Content-Length", "0") ])
                   ~status:`noContent
                   ~body:(Serializable.fromString "")
                   () );
-              ( Request.make ~verb:`get ~pathName:"/something"
-                  ~url:(fakeBaseUrl ^ "/something")
-                  (),
+              ( Request.make ~verb:`get ~pathName:"/something" (),
                 something,
                 Response.ok
                   ~headers:

--- a/src/Bindings.ml
+++ b/src/Bindings.ml
@@ -1,6 +1,15 @@
 module Node = struct
   include (Node : module type of Node with module Buffer := Node.Buffer)
 
+  module Url = struct
+    type t = { href : string } [@@bs.deriving accessors]
+
+    external make' : string -> string -> t = "URL"
+      [@@bs.module "url"] [@@bs.new]
+
+    let make pathName base = try Some (make' pathName base) with _ -> None
+  end
+
   module Buffer = struct
     include Node.Buffer
 

--- a/src/Headers.ml
+++ b/src/Headers.ml
@@ -1,5 +1,7 @@
 type t = string Js.Dict.t
 
+let get key headers = Js.Dict.get headers key
+
 let set key value headers =
   Js.Dict.fromArray
   @@ Belt.Array.concat [| (key, value) |]

--- a/src/Request.ml
+++ b/src/Request.ml
@@ -12,3 +12,5 @@ let make ?(headers = Js.Dict.empty ()) ?body ?url ~pathName ~verb () =
   { body; headers; pathName; url; verb }
 
 let empty = make ~pathName:"" ~verb:`get ()
+
+let setUrl url request = { request with url }

--- a/src/Request.ml
+++ b/src/Request.ml
@@ -3,12 +3,12 @@ type t = {
   body : Serializable.t option;
   headers : Headers.t;
   pathName : string;
-  url : string;
+  url : string option;
   verb : Http.Verb.t;
 }
 [@@bs.deriving accessors]
 
-let make ?(headers = Js.Dict.empty ()) ?body ~pathName ~url ~verb () =
+let make ?(headers = Js.Dict.empty ()) ?body ?url ~pathName ~verb () =
   { body; headers; pathName; url; verb }
 
-let empty = make ~pathName:"" ~url:"" ~verb:`get ()
+let empty = make ~pathName:"" ~verb:`get ()

--- a/tests/Pipe_test.ml
+++ b/tests/Pipe_test.ml
@@ -124,6 +124,71 @@ let () =
                   () );
             ]);
 
+      describe "resolveUrl" (fun () ->
+          testAllPipe "resolve url and set the ctx accordingly"
+            [
+              ( Request.empty,
+                ( resolveUrl ~secure:false >=> fun ctx ->
+                  ( text
+                  @@ Belt.Option.getWithDefault ctx.request.url "incorrect url"
+                  )
+                    ctx ),
+                Response.ok
+                  ~headers:
+                    (Js.Dict.fromList
+                       [
+                         ("Content-Length", "13"); ("Content-Type", "text/html");
+                       ])
+                  ~body:(Serializable.fromString "incorrect url")
+                  () );
+              ( Request.make ~pathName:"/foo" ~verb:`get (),
+                ( resolveUrl ~secure:false >=> fun ctx ->
+                  ( text
+                  @@ Belt.Option.getWithDefault ctx.request.url "incorrect url"
+                  )
+                    ctx ),
+                Response.ok
+                  ~headers:
+                    (Js.Dict.fromList
+                       [
+                         ("Content-Length", "13"); ("Content-Type", "text/html");
+                       ])
+                  ~body:(Serializable.fromString "incorrect url")
+                  () );
+              ( Request.make ~pathName:"/foo"
+                  ~headers:(Js.Dict.fromList [ ("host", "foobar.com") ])
+                  ~verb:`get (),
+                ( resolveUrl ~secure:false >=> fun ctx ->
+                  ( text
+                  @@ Belt.Option.getWithDefault ctx.request.url "incorrect url"
+                  )
+                    ctx ),
+                Response.ok
+                  ~headers:
+                    (Js.Dict.fromList
+                       [
+                         ("Content-Length", "21"); ("Content-Type", "text/html");
+                       ])
+                  ~body:(Serializable.fromString "http://foobar.com/foo")
+                  () );
+              ( Request.make ~pathName:"/foo"
+                  ~headers:(Js.Dict.fromList [ ("host", "foobar.com") ])
+                  ~verb:`get (),
+                ( resolveUrl ~secure:true >=> fun ctx ->
+                  ( text
+                  @@ Belt.Option.getWithDefault ctx.request.url "incorrect url"
+                  )
+                    ctx ),
+                Response.ok
+                  ~headers:
+                    (Js.Dict.fromList
+                       [
+                         ("Content-Length", "22"); ("Content-Type", "text/html");
+                       ])
+                  ~body:(Serializable.fromString "https://foobar.com/foo")
+                  () );
+            ]);
+
       describe "option" (fun () ->
           testAllPipe "execute pipe only if argument is some thing"
             [


### PR DESCRIPTION
As stated here: https://nodejs.org/api/http.html#http_message_url the native http(s) modules' requests (incoming messages) will _not_ expose the actual, computed, url, but instead the path name that has been provided in the request. The url is, for the native adapter, always None by default, but a pipe has been added that computes the url.