### PR TITLE
Native adapter: Add host, port, and onStart options

### DIFF
--- a/example/Main.ml
+++ b/example/Main.ml
@@ -2,4 +2,10 @@ open Core
 open Pipes
 
 let () =
-  run ~adapter:(module NativeAdapter) ~config:{ db = "postgres" } pipeline
+  run
+    ~adapter:
+      (NativeAdapter.make
+         ~onListen:(fun () ->
+           Js.log "Noir example started: http://localhost:3000")
+         ())
+    ~config:{ db = "postgres" } pipeline

--- a/src/NativeAdapter.ml
+++ b/src/NativeAdapter.ml
@@ -35,43 +35,53 @@ type t
 external createServer' : (request -> response -> unit) -> t = "createServer"
   [@@bs.module "http"]
 
-external listen' : t -> int -> unit = "listen" [@@bs.send]
+module ListenOptions = struct
+  type t = { host : string; port : int }
+end
 
-let listen f =
-  let server =
-    createServer' @@ fun ({ headers; pathName; verb } as request) response ->
-    f
-      (Request.make
-         ~body:
-           (Serializable.fromStream @@ requestToStream request)
-           (* As stated here https://nodejs.org/api/http.html#http_message_url the native http(s) modules'
-              requests (incoming message) will not compute the url by default, but it's pretty easy to add pipe
-              for that if needed. Url is then always None *)
-         ~headers ~pathName ~verb:(readVerb verb) ())
-    |> Js.Promise.then_ (fun ({ body; headers; status } : Response.t) ->
-           (* When reaching this point the status should be set, but it can be assumed as not found *)
-           let status = Belt.Option.getWithDefault status `notFound in
-           (* Set status *)
-           response.statusCode <- Http.Status.toCode status;
-           response.statusMessage <- Http.Status.toMessage status;
-           (* Set headers *)
-           headers |> Js.Dict.entries
-           |> Js.Array.forEach (fun (key, value) ->
-                  setHeader response key value);
-           match body with
-           | None -> Js.Promise.resolve @@ Http.Status.toMessage status
-           | Some (String string) -> Js.Promise.resolve string
-           | Some (Buffer buffer) ->
-               Js.Promise.resolve
-               @@ Bindings.Node.Buffer.toStringWithEncoding buffer `utf8
-           | Some (Stream stream) ->
-               Bindings.Node.Stream.Readable.consume stream)
-    |> Js.Promise.then_ (fun body ->
-           (* Write response content *)
-           write response body;
-           (* End request *) _end response;
-           Js.Promise.resolve ())
-    |> ignore
-  in
+external listen' : t -> ListenOptions.t -> (unit -> unit) Js.Nullable.t -> unit
+  = "listen"
+  [@@bs.send]
 
-  listen' server 3000
+let make ?(host = "127.0.0.1") ?(port = 3000) ?onListen () =
+  ( module struct
+    let listen f =
+      let server =
+        createServer'
+        @@ fun ({ headers; pathName; verb } as request) response ->
+        f
+          (Request.make
+             ~body:
+               (Serializable.fromStream @@ requestToStream request)
+               (* As stated here https://nodejs.org/api/http.html#http_message_url the native http(s) modules'
+                   requests (incoming message) will not compute the url by default, but it's pretty easy to add pipe
+                   for that if needed. Url is then always None *)
+             ~headers ~pathName ~verb:(readVerb verb) ())
+        |> Js.Promise.then_ (fun ({ body; headers; status } : Response.t) ->
+               (* When reaching this point the status should be set, but it can be assumed as not found *)
+               let status = Belt.Option.getWithDefault status `notFound in
+               (* Set status *)
+               response.statusCode <- Http.Status.toCode status;
+               response.statusMessage <- Http.Status.toMessage status;
+               (* Set headers *)
+               headers |> Js.Dict.entries
+               |> Js.Array.forEach (fun (key, value) ->
+                      setHeader response key value);
+               match body with
+               | None -> Js.Promise.resolve @@ Http.Status.toMessage status
+               | Some (String string) -> Js.Promise.resolve string
+               | Some (Buffer buffer) ->
+                   Js.Promise.resolve
+                   @@ Bindings.Node.Buffer.toStringWithEncoding buffer `utf8
+               | Some (Stream stream) ->
+                   Bindings.Node.Stream.Readable.consume stream)
+        |> Js.Promise.then_ (fun body ->
+               (* Write response content *)
+               write response body;
+               (* End request *) _end response;
+               Js.Promise.resolve ())
+        |> ignore
+      in
+
+      listen' server { host; port } @@ Js.Nullable.fromOption onListen
+  end : Adapter.Type )


### PR DESCRIPTION
NativeAdapter contains a make function that returns a valid Adapter module.

It allows to set host, port, and an onListen callback.

Closes https://github.com/gaku-sei/noir/issues/6