### PR TITLE
Example: Use << and >> instead of <<< and >>> for function composition

### DIFF
--- a/example/Pipes.ml
+++ b/example/Pipes.ml
@@ -9,7 +9,7 @@ type payload = { name : string; age : int } [@@decco.decode]
 
 let decodeWith decoder =
   let tryParse string = try Js.Json.parseExn string with _ -> Js.Json.null in
-  tryParse >>> decoder >>> function
+  tryParse >> decoder >> function
   | Ok ok -> Ok ok
   | Error { Decco.message; path } ->
       Error
@@ -28,7 +28,7 @@ let hello =
   >=> ( route "noir"
       >=> setHeader "X-Powered-By" "Noir"
       >=> text "Say hello to Noir!!"
-      <|> capture (text <<< ( ^ ) "Say hello to ") )
+      <|> capture (text << ( ^ ) "Say hello to ") )
 
 let noContent = route "no-content" >=> status `noContent
 

--- a/example/Util.ml
+++ b/example/Util.ml
@@ -1,3 +1,3 @@
-let ( <<< ) f g x = f @@ g x
+let ( << ) f g x = f @@ g x
 
-let ( >>> ) f g x = g @@ f x
+let ( >> ) f g x = g @@ f x


### PR DESCRIPTION
<<< and >>> were borrowed from PureScript, but it's probably better to use << and >> for more consistency with the current OCaml/BuckleScript ecosystem (like [Relude](https://github.com/reazen/relude) for instance).